### PR TITLE
Remove duplicate suffix from queue name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.2 / 2014-04-30
+* [BIGFIX] Do not add suffix to queue names - added by Propono.
+
 # 0.9.1 / 2014-04-30
 * [FEATURE] Raise exceptions when thread dies 
 

--- a/lib/larva/listener.rb
+++ b/lib/larva/listener.rb
@@ -12,7 +12,7 @@ module Larva
     end
 
     def listen
-      queue_name = "#{topic_name}#{Propono.config.queue_suffix}"
+      queue_name = "#{topic_name}"
       Propono.config.logger.info "Starting to listen to queue #{queue_name}"
       Propono.listen_to_queue("#{queue_name}") do |message, context|
         Propono.config.logger.context_id = context[:id]

--- a/lib/larva/version.rb
+++ b/lib/larva/version.rb
@@ -1,3 +1,3 @@
 module Larva
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end

--- a/test/listener_test.rb
+++ b/test/listener_test.rb
@@ -4,18 +4,13 @@ module Larva
   class ListenerTest < Minitest::Test
     def test_listen_to_queue_is_called
       topic_name = "Foo"
-      queue_suffix = "bar"
-      Propono.config.queue_suffix = queue_suffix
-      Propono.expects(:listen_to_queue).with("#{topic_name}#{queue_suffix}")
+      Propono.expects(:listen_to_queue).with("#{topic_name}")
       Larva::Listener.listen(topic_name, nil)
     end
 
     def test_listener_logs_listening_message
       topic_name = "Foo"
-      queue_suffix = "bar"
-      Propono.config.queue_suffix = queue_suffix
-
-      message = "Starting to listen to queue #{topic_name}#{queue_suffix}"
+      message = "Starting to listen to queue #{topic_name}"
       Propono.config.logger.expects(:info).with(message)
       Propono.stubs(:listen_to_queue)
       Larva::Listener.listen(topic_name, nil)


### PR DESCRIPTION
Binder missito will make use of a queue suffix - a feature added to aid development, but not used in production before.

Testing has shown that a queue's suffix is added twice. With the config file:

```
development:
  ...
  application_name: development_binder_missito
  queue_suffix: _binder
```

we hope to get a queue name <application_name><topic><suffix> 
i.e. development_binder_missito-user_binder

Testing showed the resulting queue's were:

```
~ $ aws sqs list-queues --output=text 
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_binder_binder
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_binder_binder-corrupt
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_binder_binder-failed
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_binder_binder-slow
```

Further testing, changing the config file to:

```
development:
  ...
  application_name: development_binder_missito
  queue_suffix: _suffix
```

created the following queue's:

```
~ $ aws sqs list-queues --output=text 
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_suffix_suffix
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_suffix_suffix-corrupt
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_suffix_suffix-failed
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_suffix_suffix-slow
```

This change removes the addition of a second copy of the suffix to the queue name from larva. The suffix is added by Propono.

Using this branch the queue's created are:

```
~ $ aws sqs list-queues --output=text 
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_binder
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_binder-corrupt
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_binder-failed
QUEUEURLS   https://eu-west-1.queue.amazonaws.com/260921037403/development_binder_missito-user_binder-slow
```
