### PR TITLE
Extend propono configuration

### DIFF
--- a/template/config/propono.yml
+++ b/template/config/propono.yml
@@ -4,9 +4,15 @@ development:
   region: eu-west-1
   application_name: development_larva_spawn
   queue_suffix:
+  max_retries: 1
+  udp_host: pergo.meducation.net
+  udp_port: '9732'
 
 production:
   use_iam_profile: true
   region: eu-west-1
   application_name: larva_spawn
   queue_suffix:
+  max_retries: 1
+  udp_host: pergo.meducation.net
+  udp_port: '9732'

--- a/test/configurator_test.rb
+++ b/test/configurator_test.rb
@@ -37,6 +37,7 @@ module Larva
       assert_equal "pergo.meducation.net", Propono.config.udp_host
       assert_equal "9732", Propono.config.udp_port
       assert_equal Filum.logger, Propono.config.logger
+      assert_equal 1, Propono.config.max_retries
     end
 
     def test_propono_gets_config_with_env
@@ -47,6 +48,7 @@ module Larva
       assert_equal "pergo.meducation.net", Propono.config.udp_host
       assert_equal "9732", Propono.config.udp_port
       assert_equal Filum.logger, Propono.config.logger
+      assert_equal 1, Propono.config.max_retries
     end
   end
 end


### PR DESCRIPTION
It adds the possibility of configure all propono config variables from the `propono.yml`, like `max_retries`, `tcp_host`, `tcp_port`, `udp_host`, `udp_port`.
